### PR TITLE
Change undefined texImage2DImage calls to texImage2D

### DIFF
--- a/web/learn_gl.dart
+++ b/web/learn_gl.dart
@@ -285,7 +285,7 @@ Future<Texture> loadTexture(String url, handle(Texture tex, ImageElement ele)) {
 void handleMipMapTexture(Texture texture, ImageElement image) {
   gl.pixelStorei(UNPACK_FLIP_Y_WEBGL, 1);
   gl.bindTexture(TEXTURE_2D, texture);
-  gl.texImage2DImage(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, image);
+  gl.texImage2D(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, image);
   gl.texParameteri(TEXTURE_2D, TEXTURE_MAG_FILTER, LINEAR);
   gl.texParameteri(TEXTURE_2D, TEXTURE_MIN_FILTER, LINEAR_MIPMAP_NEAREST);
   gl.generateMipmap(TEXTURE_2D);

--- a/web/lesson10.dart
+++ b/web/lesson10.dart
@@ -33,7 +33,7 @@ class Lesson10 extends Lesson {
     loadTexture("mcdole.gif", (Texture texture, ImageElement ele) {
       gl.pixelStorei(UNPACK_FLIP_Y_WEBGL, 1);
       gl.bindTexture(TEXTURE_2D, texture);
-      gl.texImage2DImage(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, ele);
+      gl.texImage2D(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, ele);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MAG_FILTER, LINEAR);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MIN_FILTER, LINEAR);
       this.texture = texture;

--- a/web/lesson5.dart
+++ b/web/lesson5.dart
@@ -29,7 +29,7 @@ class Lesson5 extends Lesson {
     loadTexture("nehe.gif", (Texture texture, ImageElement element) {
       gl.bindTexture(TEXTURE_2D, texture);
       gl.pixelStorei(UNPACK_FLIP_Y_WEBGL, 1);
-      gl.texImage2DImage(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, element);
+      gl.texImage2D(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, element);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MAG_FILTER, NEAREST);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MIN_FILTER, NEAREST);
       gl.bindTexture(TEXTURE_2D, null);

--- a/web/lesson6.dart
+++ b/web/lesson6.dart
@@ -67,19 +67,19 @@ class Lesson6 extends Lesson {
       textures.add(text);
 
       gl.bindTexture(TEXTURE_2D, textures[0]);
-      gl.texImage2DImage(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, ele);
+      gl.texImage2D(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, ele);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MAG_FILTER, NEAREST);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MIN_FILTER, NEAREST);
 
       textures.add(gl.createTexture());
       gl.bindTexture(TEXTURE_2D, textures[1]);
-      gl.texImage2DImage(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, ele);
+      gl.texImage2D(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, ele);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MAG_FILTER, LINEAR);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MIN_FILTER, LINEAR);
 
       textures.add(gl.createTexture());
       gl.bindTexture(TEXTURE_2D, textures[2]);
-      gl.texImage2DImage(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, ele);
+      gl.texImage2D(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, ele);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MAG_FILTER, LINEAR);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MIN_FILTER, LINEAR_MIPMAP_NEAREST);
       gl.generateMipmap(TEXTURE_2D);

--- a/web/lesson9.dart
+++ b/web/lesson9.dart
@@ -31,7 +31,7 @@ class Lesson9 extends Lesson {
     loadTexture("star.gif", (Texture texture, ImageElement ele) {
       gl.pixelStorei(UNPACK_FLIP_Y_WEBGL, 1);
       gl.bindTexture(TEXTURE_2D, texture);
-      gl.texImage2DImage(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, ele);
+      gl.texImage2D(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, ele);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MAG_FILTER, LINEAR);
       gl.texParameteri(TEXTURE_2D, TEXTURE_MIN_FILTER, LINEAR);
 


### PR DESCRIPTION
There were several warnings about texImage2DImage when building, e.g.
`[Warning from Dart2JS on learn_gl|web/learn_gl.dart]:
web/lesson5.dart:32:7:
The method 'texImage2DImage' is not defined for the class 'RenderingContext'.
      gl.texImage2DImage(TEXTURE_2D, 0, RGBA, RGBA, UNSIGNED_BYTE, element);
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`

Nothing after lesson 4 was working properly with these warnings, so I simply removed the second "Image" from the method name. This texImage2D method is documented [here](https://api.dartlang.org/stable/1.20.1/dart-web_gl/RenderingContext/texImage2D.html). Everything seems to work correctly now.

It looks like the texImage2DImage version was removed in [this commit](https://github.com/dart-lang/sdk/commit/a29edf769f8515c99870131c6385fe417fcfbce8).